### PR TITLE
get list

### DIFF
--- a/connect/resource/automation.py
+++ b/connect/resource/automation.py
@@ -18,7 +18,7 @@ class AutomationResource(BaseResource):
     limit = 1000
 
     def get_filters(self, status='pending', **kwargs):
-        # type: (str, Dict[str, str]) -> Dict[str, Any]
+        # type: (str, Dict[str, Any]) -> Dict[str, Any]
         return super(AutomationResource, self).get_filters(status=status, **kwargs)
 
     def process(self):

--- a/connect/resource/automation.py
+++ b/connect/resource/automation.py
@@ -17,12 +17,9 @@ from .template import TemplateResource
 class AutomationResource(BaseResource):
     limit = 1000
 
-    def get_filters(self, status='pending'):
-        # type: (str) -> Dict[str, Any]
-        filters = super(AutomationResource, self).get_filters()
-        if status:
-            filters['status'] = status
-        return filters
+    def get_filters(self, status='pending', **kwargs):
+        # type: (str, Dict[str, str]) -> Dict[str, Any]
+        return super(AutomationResource, self).get_filters(status=status, **kwargs)
 
     def process(self):
         # type: () -> None

--- a/connect/resource/automation.py
+++ b/connect/resource/automation.py
@@ -17,13 +17,13 @@ from .template import TemplateResource
 class AutomationResource(BaseResource):
     limit = 1000
 
-    def get_filters(self, status='pending', **kwargs):
+    def filters(self, status='pending', **kwargs):
         # type: (str, Dict[str, Any]) -> Dict[str, Any]
-        return super(AutomationResource, self).get_filters(status=status, **kwargs)
+        return super(AutomationResource, self).filters(status=status, **kwargs)
 
     def process(self):
         # type: () -> None
-        for request in self.get_list():
+        for request in self.list():
             self.dispatch(request)
 
     def dispatch(self, request):

--- a/connect/resource/automation.py
+++ b/connect/resource/automation.py
@@ -17,16 +17,16 @@ from .template import TemplateResource
 class AutomationResource(BaseResource):
     limit = 1000
 
-    def build_filter(self, status='pending'):
+    def get_filters(self, status='pending'):
         # type: (str) -> Dict[str, Any]
-        filters = super(AutomationResource, self).build_filter()
+        filters = super(AutomationResource, self).get_filters()
         if status:
             filters['status'] = status
         return filters
 
     def process(self):
         # type: () -> None
-        for request in self.list:
+        for request in self.get_list():
             self.dispatch(request)
 
     def dispatch(self, request):

--- a/connect/resource/base.py
+++ b/connect/resource/base.py
@@ -127,27 +127,26 @@ class BaseResource(object):
         # type: () -> Config
         return self.api.config
 
-    @property
-    def list(self):
-        # type: () -> List[Any]
-        filters = self.build_filter()
-        logger.info('Get list request by filter - {}'.format(filters))
-        response = self.api.get(params=filters)
-        return self._load_schema(response)
-
-    def build_filter(self):
-        # type: () -> Dict[str, Any]
-        res_filter = {}
-        if self.limit:
-            res_filter['limit'] = self.limit
-        return res_filter
-
     def get(self, pk):
         # type: (str) -> Any
         response = self.api.get(path=pk)
         objects = self._load_schema(response)
         if isinstance(objects, list) and len(objects) > 0:
             return objects[0]
+
+    def get_filters(self):
+        # type: () -> Dict[str, Any]
+        filters = {}
+        if self.limit:
+            filters['limit'] = self.limit
+        return filters
+
+    def get_list(self, filters=None):
+        # type: (Dict[str, Any]) -> List[Any]
+        filters = filters or self.get_filters()
+        logger.info('Get list request with filters - {}'.format(filters))
+        response = self.api.get(params=filters)
+        return self._load_schema(response)
 
     def _load_schema(self, response, many=None, schema=None):
         # type: (str, bool, BaseSchema) -> Union[List[Any], Any]

--- a/connect/resource/base.py
+++ b/connect/resource/base.py
@@ -134,11 +134,13 @@ class BaseResource(object):
         if isinstance(objects, list) and len(objects) > 0:
             return objects[0]
 
-    def get_filters(self):
-        # type: () -> Dict[str, Any]
+    def get_filters(self, **kwargs):
+        # type: (Dict[str, str]) -> Dict[str, Any]
         filters = {}
         if self.limit:
             filters['limit'] = self.limit
+        for key, val in kwargs.items():
+            filters[key] = val
         return filters
 
     def get_list(self, filters=None):

--- a/connect/resource/base.py
+++ b/connect/resource/base.py
@@ -135,7 +135,7 @@ class BaseResource(object):
             return objects[0]
 
     def get_filters(self, **kwargs):
-        # type: (Dict[str, str]) -> Dict[str, Any]
+        # type: (Dict[str, Any]) -> Dict[str, Any]
         filters = {}
         if self.limit:
             filters['limit'] = self.limit

--- a/connect/resource/base.py
+++ b/connect/resource/base.py
@@ -134,7 +134,7 @@ class BaseResource(object):
         if isinstance(objects, list) and len(objects) > 0:
             return objects[0]
 
-    def get_filters(self, **kwargs):
+    def filters(self, **kwargs):
         # type: (Dict[str, Any]) -> Dict[str, Any]
         filters = {}
         if self.limit:
@@ -143,11 +143,11 @@ class BaseResource(object):
             filters[key] = val
         return filters
 
-    def get_list(self, filters=None):
+    def list(self, filters=None):
         # type: (Dict[str, Any]) -> List[Any]
-        filters = filters or self.get_filters()
+        filters = filters or self.filters()
         logger.info('Get list request with filters - {}'.format(filters))
-        response = self.api.get(params=filters)
+        response, _ = self._api.get(params=filters)
         return self._load_schema(response)
 
     def _load_schema(self, response, many=None, schema=None):

--- a/connect/resource/fulfillment_automation.py
+++ b/connect/resource/fulfillment_automation.py
@@ -21,9 +21,9 @@ class FulfillmentAutomation(AutomationResource):
     resource = 'requests'
     schema = FulfillmentSchema(many=True)
 
-    def get_filters(self, status='pending', **kwargs):
+    def filters(self, status='pending', **kwargs):
         # type: (str, Dict[str, Any]) -> Dict[str, Any]
-        filters = super(FulfillmentAutomation, self).get_filters(status=status, **kwargs)
+        filters = super(FulfillmentAutomation, self).filters(status=status, **kwargs)
         if self.config.products:
             filters['asset.product.id__in'] = ','.join(self.config.products)
         return filters

--- a/connect/resource/fulfillment_automation.py
+++ b/connect/resource/fulfillment_automation.py
@@ -22,7 +22,7 @@ class FulfillmentAutomation(AutomationResource):
     schema = FulfillmentSchema(many=True)
 
     def get_filters(self, status='pending', **kwargs):
-        # type: (str, Dict[str, str]) -> Dict[str, Any]
+        # type: (str, Dict[str, Any]) -> Dict[str, Any]
         filters = super(FulfillmentAutomation, self).get_filters(status=status, **kwargs)
         if self.config.products:
             filters['asset.product.id__in'] = ','.join(self.config.products)

--- a/connect/resource/fulfillment_automation.py
+++ b/connect/resource/fulfillment_automation.py
@@ -21,9 +21,9 @@ class FulfillmentAutomation(AutomationResource):
     resource = 'requests'
     schema = FulfillmentSchema(many=True)
 
-    def get_filters(self, status='pending'):
-        # type: (str) -> Dict[str, Any]
-        filters = super(FulfillmentAutomation, self).get_filters(status)
+    def get_filters(self, status='pending', **kwargs):
+        # type: (str, Dict[str, str]) -> Dict[str, Any]
+        filters = super(FulfillmentAutomation, self).get_filters(status=status, **kwargs)
         if self.config.products:
             filters['asset.product.id__in'] = ','.join(self.config.products)
         return filters

--- a/connect/resource/fulfillment_automation.py
+++ b/connect/resource/fulfillment_automation.py
@@ -21,9 +21,9 @@ class FulfillmentAutomation(AutomationResource):
     resource = 'requests'
     schema = FulfillmentSchema(many=True)
 
-    def build_filter(self, status='pending'):
+    def get_filters(self, status='pending'):
         # type: (str) -> Dict[str, Any]
-        filters = super(FulfillmentAutomation, self).build_filter(status)
+        filters = super(FulfillmentAutomation, self).get_filters(status)
         if self.config.products:
             filters['asset.product.id__in'] = ','.join(self.config.products)
         return filters

--- a/connect/resource/template.py
+++ b/connect/resource/template.py
@@ -4,7 +4,7 @@
 This file is part of the Ingram Micro Cloud Blue Connect SDK.
 Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
-from typing import List, Any
+from typing import List, Any, Dict
 
 from connect.models import ActivationTemplateResponse, ActivationTileResponse
 from .base import BaseResource
@@ -17,10 +17,9 @@ class TemplateResource(BaseResource):
     """
     resource = 'templates'
 
-    @property
-    def list(self):
-        # type: () -> List[Any]
-        raise AttributeError('This resource do not have method `list`')
+    def get_list(self, filters=None):
+        # type: (Dict[str, Any]) -> List[Any]
+        raise AttributeError('This resource do not have method `get_list`')
 
     def render(self, pk, request_id):
         # type: (str, str) -> ActivationTileResponse

--- a/connect/resource/template.py
+++ b/connect/resource/template.py
@@ -19,7 +19,7 @@ class TemplateResource(BaseResource):
 
     def list(self, filters=None):
         # type: (Dict[str, Any]) -> List[Any]
-        raise AttributeError('This resource do not have method `get_list`')
+        raise AttributeError('This resource do not have method `list`')
 
     def render(self, pk, request_id):
         # type: (str, str) -> ActivationTileResponse

--- a/connect/resource/template.py
+++ b/connect/resource/template.py
@@ -17,7 +17,7 @@ class TemplateResource(BaseResource):
     """
     resource = 'templates'
 
-    def get_list(self, filters=None):
+    def list(self, filters=None):
         # type: (Dict[str, Any]) -> List[Any]
         raise AttributeError('This resource do not have method `get_list`')
 

--- a/connect/resource/usage_automation.py
+++ b/connect/resource/usage_automation.py
@@ -25,7 +25,7 @@ class UsageAutomation(AutomationResource):
     schema = FileSchema(many=True)
 
     def get_filters(self, status='listed', **kwargs):
-        # type: (str, Dict[str, str]) -> Dict[str, Any]
+        # type: (str, Dict[str, Any]) -> Dict[str, Any]
         filters = super(UsageAutomation, self).get_filters(status, **kwargs)
         if self.config.products:
             filters['product__id'] = ','.join(self.config.products)

--- a/connect/resource/usage_automation.py
+++ b/connect/resource/usage_automation.py
@@ -24,9 +24,9 @@ class UsageAutomation(AutomationResource):
     resource = 'usage/files'
     schema = FileSchema(many=True)
 
-    def build_filter(self, status='listed'):
+    def get_filters(self, status='listed'):
         # type: (str) -> Dict[str, Any]
-        filters = super(UsageAutomation, self).build_filter(status)
+        filters = super(UsageAutomation, self).get_filters(status)
         if self.config.products:
             filters['product__id'] = ','.join(self.config.products)
         return filters

--- a/connect/resource/usage_automation.py
+++ b/connect/resource/usage_automation.py
@@ -24,9 +24,9 @@ class UsageAutomation(AutomationResource):
     resource = 'usage/files'
     schema = FileSchema(many=True)
 
-    def get_filters(self, status='listed'):
-        # type: (str) -> Dict[str, Any]
-        filters = super(UsageAutomation, self).get_filters(status)
+    def get_filters(self, status='listed', **kwargs):
+        # type: (str, Dict[str, str]) -> Dict[str, Any]
+        filters = super(UsageAutomation, self).get_filters(status, **kwargs)
         if self.config.products:
             filters['product__id'] = ','.join(self.config.products)
         return filters

--- a/connect/resource/usage_automation.py
+++ b/connect/resource/usage_automation.py
@@ -24,9 +24,9 @@ class UsageAutomation(AutomationResource):
     resource = 'usage/files'
     schema = FileSchema(many=True)
 
-    def get_filters(self, status='listed', **kwargs):
+    def filters(self, status='listed', **kwargs):
         # type: (str, Dict[str, Any]) -> Dict[str, Any]
-        filters = super(UsageAutomation, self).get_filters(status, **kwargs)
+        filters = super(UsageAutomation, self).filters(status, **kwargs)
         if self.config.products:
             filters['product__id'] = ','.join(self.config.products)
         return filters

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -61,7 +61,7 @@ def test_create_model_from_response():
 
     # Get requests from response
     resource = FulfillmentAutomation()
-    requests = resource.list
+    requests = resource.get_list()
     request_obj = resource.get(pk='PR-000-000-000')
 
     # Assert that all properties exist
@@ -102,7 +102,7 @@ def test_create_model_from_response():
 @patch('requests.get', MagicMock(return_value=_get_response2_ok()))
 def test_fulfillment_items():
     # Get request
-    requests = FulfillmentAutomation().list
+    requests = FulfillmentAutomation().get_list()
     assert isinstance(requests, list)
     assert len(requests) == 1
     request = requests[0]
@@ -133,7 +133,7 @@ def test_fulfillment_items():
 @patch('requests.get', MagicMock(return_value=_get_response2_ok()))
 def test_asset_methods():
     # Get asset
-    requests = FulfillmentAutomation().list
+    requests = FulfillmentAutomation().get_list()
     assert len(requests) == 1
     assert isinstance(requests[0], Fulfillment)
     asset = requests[0].asset

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,7 +59,7 @@ def test_create_model_from_response():
 
     # Get requests from response
     resource = FulfillmentAutomation()
-    requests = resource.get_list()
+    requests = resource.list()
     request_obj = resource.get(pk='PR-000-000-000')
 
     # Assert that all properties exist
@@ -100,7 +100,7 @@ def test_create_model_from_response():
 @patch('requests.get', MagicMock(return_value=_get_response2_ok()))
 def test_fulfillment_items():
     # Get request
-    requests = FulfillmentAutomation().get_list()
+    requests = FulfillmentAutomation().list()
     assert isinstance(requests, list)
     assert len(requests) == 1
     request = requests[0]
@@ -131,7 +131,7 @@ def test_fulfillment_items():
 @patch('requests.get', MagicMock(return_value=_get_response2_ok()))
 def test_asset_methods():
     # Get asset
-    requests = FulfillmentAutomation().get_list()
+    requests = FulfillmentAutomation().list()
     assert len(requests) == 1
     assert isinstance(requests[0], Fulfillment)
     asset = requests[0].asset

--- a/tests/test_tier_config.py
+++ b/tests/test_tier_config.py
@@ -41,7 +41,7 @@ def _get_response_ok_invalid_product():
 
 @patch('requests.get', MagicMock(return_value=_get_response_ok()))
 def test_create_resource():
-    requests = TierConfigAutomation().list
+    requests = TierConfigAutomation().get_list()
     assert isinstance(requests, list)
     assert len(requests) == 1
 

--- a/tests/test_tier_config.py
+++ b/tests/test_tier_config.py
@@ -42,7 +42,7 @@ def _get_response_ok_invalid_product():
 
 @patch('requests.get', MagicMock(return_value=_get_response_ok()))
 def test_create_resource():
-    requests = TierConfigAutomation().get_list()
+    requests = TierConfigAutomation().list()
     assert isinstance(requests, list)
     assert len(requests) == 1
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -35,7 +35,7 @@ def _get_response_ok2():
 
 @patch('requests.get', MagicMock(return_value=_get_response_ok()))
 def test_create_resource():
-    requests = UsageAutomation().list
+    requests = UsageAutomation().get_list()
     assert isinstance(requests, list)
     assert len(requests) == 8
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -33,7 +33,7 @@ def _get_response_ok2():
 
 @patch('requests.get', MagicMock(return_value=_get_response_ok()))
 def test_create_resource():
-    requests = UsageAutomation().get_list()
+    requests = UsageAutomation().list()
     assert isinstance(requests, list)
     assert len(requests) == 8
 

--- a/tests/test_usage_file.py
+++ b/tests/test_usage_file.py
@@ -35,7 +35,7 @@ def _get_response_ok(*args, **kwargs):
 
 @patch('requests.get', MagicMock(return_value=_get_response_ok()))
 def test_create_resource():
-    requests = UsageFileAutomationTester().get_list()
+    requests = UsageFileAutomationTester().list()
     assert isinstance(requests, list)
     assert len(requests) == 1
 

--- a/tests/test_usage_file.py
+++ b/tests/test_usage_file.py
@@ -36,7 +36,7 @@ def _get_response_ok(*args, **kwargs):
 
 @patch('requests.get', MagicMock(return_value=_get_response_ok()))
 def test_create_resource():
-    requests = UsageFileAutomationTester().list
+    requests = UsageFileAutomationTester().get_list()
     assert isinstance(requests, list)
     assert len(requests) == 1
 


### PR DESCRIPTION
Rename BaseResource's build_filter and list as get_filters and get_list respectively (the latter being now a method instead of a property). get_list now accepts optional filters (get_filters is used if none provided).