### PR TITLE
Fix on Item.quantity parsing

### DIFF
--- a/connect/models/asset.py
+++ b/connect/models/asset.py
@@ -48,8 +48,8 @@ class AssetSchema(BaseSchema):
     connection = fields.Nested(
         ConnectionSchema, only=('id', 'type', 'provider', 'vendor'),
     )
-    items = fields.List(fields.Nested(ItemSchema))
-    params = fields.List(fields.Nested(ParamSchema))
+    items = fields.Nested(ItemSchema, many=True)
+    params = fields.Nested(ParamSchema, many=True)
     tiers = fields.Nested(TiersSchema)
 
     @post_load

--- a/connect/models/base.py
+++ b/connect/models/base.py
@@ -9,7 +9,7 @@ import json
 from marshmallow import Schema, fields, post_load
 
 
-class BaseModel:
+class BaseModel(object):
     id = None  # type: str
 
     def __init__(self, **kwargs):

--- a/connect/models/company.py
+++ b/connect/models/company.py
@@ -20,3 +20,15 @@ class CompanySchema(BaseSchema):
     @post_load
     def make_object(self, data):
         return Company(**data)
+
+
+class User(BaseModel):
+    name = None  # type: str
+
+
+class UserSchema(BaseSchema):
+    name = fields.Str()
+
+    @post_load
+    def make_object(self, data):
+        return User(**data)

--- a/connect/models/contact.py
+++ b/connect/models/contact.py
@@ -6,6 +6,7 @@ Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 
 from marshmallow import fields, post_load
+from typing import Optional
 
 from .base import BaseModel, BaseSchema
 
@@ -30,15 +31,15 @@ class PhoneNumberSchema(BaseSchema):
 
 class Contact(BaseModel):
     email = None  # type: str
-    first_name = None  # type: str
-    last_name = None  # type: str
+    first_name = None  # type: Optional[str]
+    last_name = None  # type: Optional[str]
     phone_number = None  # type: PhoneNumber
 
 
 class ContactSchema(BaseSchema):
     email = fields.Str()
-    first_name = fields.Str()
-    last_name = fields.Str()
+    first_name = fields.Str(allow_none=True)
+    last_name = fields.Str(allow_none=True)
     phone_number = fields.Nested(PhoneNumberSchema)
 
     @post_load
@@ -48,7 +49,7 @@ class ContactSchema(BaseSchema):
 
 class ContactInfo(BaseModel):
     address_line1 = None  # type: str
-    address_line2 = None  # type: str
+    address_line2 = None  # type: Optional[str]
     city = None  # type: str
     contact = None  # type: Contact
     country = None  # type: str
@@ -58,7 +59,7 @@ class ContactInfo(BaseModel):
 
 class ContactInfoSchema(BaseSchema):
     address_line1 = fields.Str()
-    address_line2 = fields.Str()
+    address_line2 = fields.Str(allow_none=True)
     city = fields.Str()
     contact = fields.Nested(ContactSchema)
     country = fields.Str()

--- a/connect/models/event.py
+++ b/connect/models/event.py
@@ -8,17 +8,17 @@ from marshmallow import fields, post_load
 from typing import Optional
 
 from connect.models.base import BaseModel, BaseSchema
-from connect.models.company import CompanySchema, Company
+from connect.models.company import User, UserSchema
 
 
 class EventInfo(BaseModel):
     at = None  # type: Optional[str]
-    by = None  # type: Optional[Company]
+    by = None  # type: Optional[User]
 
 
 class EventInfoSchema(BaseSchema):
     at = fields.DateTime(allow_none=True)
-    by = fields.Nested(CompanySchema, allow_none=True)
+    by = fields.Nested(UserSchema, allow_none=True)
 
     @post_load
     def make_object(self, data):

--- a/connect/models/event.py
+++ b/connect/models/event.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""
+This file is part of the Ingram Micro Cloud Blue Connect SDK.
+Copyright (c) 2019 Ingram Micro. All Rights Reserved.
+"""
+from marshmallow import fields, post_load
+from typing import Optional
+
+from connect.models.base import BaseModel, BaseSchema
+from connect.models.company import CompanySchema, Company
+
+
+class EventInfo(BaseModel):
+    at = None  # type: Optional[str]
+    by = None  # type: Optional[Company]
+
+
+class EventInfoSchema(BaseSchema):
+    at = fields.DateTime(allow_none=True)
+    by = fields.Nested(CompanySchema, allow_none=True)
+
+    @post_load
+    def make_object(self, data):
+        return EventInfo(**data)
+
+
+class Events(BaseModel):
+    created = None  # type: EventInfo
+    inquired = None  # type: EventInfo
+    pended = None  # type: EventInfo
+    validated = None  # type: EventInfo
+    updated = None  # type: EventInfo
+
+
+class EventsSchema(BaseSchema):
+    created = fields.Nested(EventInfoSchema)
+    inquired = fields.Nested(EventInfoSchema)
+    pended = fields.Nested(EventInfoSchema)
+    validated = fields.Nested(EventInfoSchema)
+    updated = fields.Nested(EventInfoSchema)
+
+    @post_load
+    def make_object(self, data):
+        return Events(**data)

--- a/connect/models/hub.py
+++ b/connect/models/hub.py
@@ -6,16 +6,55 @@ Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 
 from marshmallow import Schema, fields, post_load
+from typing import Optional
 
+from connect.models.company import Company, CompanySchema
+from connect.models.event import Events, EventsSchema
 from .base import BaseModel, BaseSchema
+
+
+class HubInstance(BaseModel):
+    type = None  # type: str
+
+
+class HubInstanceSchema(BaseSchema):
+    type = fields.Str()
+
+    @post_load
+    def make_object(self, data):
+        return HubInstance(**data)
+
+
+class HubStats(BaseModel):
+    connections = None  # type: int
+    marketplaces = None  # type: int
+
+
+class HubStatsSchema(BaseSchema):
+    connections = fields.Int()
+    marketplaces = fields.Int()
+
+    @post_load
+    def make_object(self, data):
+        return HubStats(**data)
 
 
 class Hub(BaseModel):
     name = None  # type: str
+    company = None  # type: Company
+    description = None  # type: Optional[str]
+    instance = None  # type: HubInstance
+    events = None  # type: Events
+    stats = None  # type: HubStats
 
 
 class HubSchema(BaseSchema):
     name = fields.Str()
+    company = fields.Nested(CompanySchema)
+    description = fields.Str(allow_none=True)
+    instance = fields.Nested(HubInstanceSchema)
+    events = fields.Nested(EventsSchema)
+    stats = fields.Nested(HubStatsSchema)
 
     @post_load
     def make_object(self, data):

--- a/connect/models/marketplace.py
+++ b/connect/models/marketplace.py
@@ -9,7 +9,7 @@ from marshmallow import fields, post_load
 from typing import Optional, List
 
 from .base import BaseModel, BaseSchema
-from .company import Company, CompanySchema
+from .company import Company, CompanySchema, User, UserSchema
 from .hub import Hubs, HubsSchema
 
 
@@ -59,7 +59,7 @@ class Agreement(BaseModel):
     updated = None  # type: str
     owner = None  # type: Company
     stats = None  # type: Optional[AgreementStats]
-    author = None  # type: Optional[Company]
+    author = None  # type: Optional[User]
     version = None  # type: int
     active = None  # type: bool
     link = None  # type: str
@@ -78,7 +78,7 @@ class AgreementSchema(BaseSchema):
     updated = fields.DateTime()
     owner = fields.Nested(CompanySchema)
     stats = fields.Nested(AgreementStatsSchema, allow_none=True)
-    author = fields.Nested(CompanySchema, allow_none=True)
+    author = fields.Nested(UserSchema, allow_none=True)
     version = fields.Int()
     active = fields.Bool()
     link = fields.Str()
@@ -117,13 +117,13 @@ class Contract(BaseModel):
     agreement = None  # type: Agreement
     marketplace = None  # type: Optional[Marketplace]
     owner = None  # type: Optional[Company]
-    creator = None  # type: Company
+    creator = None  # type: User
     created = None  # type: str
     updated = None  # type: str
     enrolled = None  # type: Optional[str]
     version_created = None  # type: str
     activation = None  # type: Activation
-    signee = None  # type: Optional[Company]
+    signee = None  # type: Optional[User]
 
 
 class ContractSchema(BaseSchema):
@@ -134,13 +134,13 @@ class ContractSchema(BaseSchema):
     agreement = fields.Nested(AgreementSchema, only=('id', 'name'))
     marketplace = fields.Nested(MarketplaceSchema, only=('id', 'name'), allow_none=True)
     owner = fields.Nested(CompanySchema, only=('id', 'name'), allow_none=True)
-    creator = fields.Nested(CompanySchema, only=('id', 'name'))
+    creator = fields.Nested(UserSchema, only=('id', 'name'))
     created = fields.DateTime()
     updated = fields.DateTime()
     enrolled = fields.Str(allow_none=True)
     version_created = fields.DateTime()
     activation = fields.Nested(ActivationSchema)
-    signee = fields.Nested(CompanySchema, only=('id', 'name'), allow_none=True)
+    signee = fields.Nested(UserSchema, only=('id', 'name'), allow_none=True)
 
     @post_load
     def make_object(self, data):

--- a/connect/models/marketplace.py
+++ b/connect/models/marketplace.py
@@ -6,6 +6,7 @@ Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 
 from marshmallow import fields, post_load
+from typing import Optional, List
 
 from .base import BaseModel, BaseSchema
 from .company import Company, CompanySchema
@@ -14,26 +15,40 @@ from .hub import Hubs, HubsSchema
 
 class Marketplace(BaseModel):
     name = None  # type: str
-    zone = None  # type: str
     description = None  # type: str
     active_contract = None  # type: int
     icon = None  # type: str
     owner = None  # type: Company
-    hubs = None  # type: Hubs
+    hubs = None  # type: List[Hubs]
+    zone = None  # type: str
 
 
 class MarketplaceSchema(BaseSchema):
     name = fields.Str()
-    zone = fields.Str()
     description = fields.Str()
     active_contract = fields.Int()
     icon = fields.Str()
     owner = fields.Nested(CompanySchema, only=('id', 'name'))
-    hubs = fields.List(fields.Nested(HubsSchema, only=('id', 'name')))
+    hubs = fields.Nested(HubsSchema, many=True)
+    zone = fields.Str()
 
     @post_load
     def make_object(self, data):
         return Marketplace(**data)
+
+
+class AgreementStats(BaseModel):
+    contracts = None  # type: Optional[int]
+    versions = None  # type: int
+
+
+class AgreementStatsSchema(BaseSchema):
+    contracts = fields.Int(allow_none=True)
+    versions = fields.Int()
+
+    @post_load
+    def make_object(self, data):
+        return AgreementStatsSchema(**data)
 
 
 class Agreement(BaseModel):
@@ -43,12 +58,16 @@ class Agreement(BaseModel):
     created = None  # type: str
     updated = None  # type: str
     owner = None  # type: Company
-    stats = None  # type: dict
-    active = None  # type: bool
+    stats = None  # type: Optional[AgreementStats]
+    author = None  # type: Optional[Company]
     version = None  # type: int
+    active = None  # type: bool
     link = None  # type: str
     version_created = None  # type: str
     version_contracts = None  # type: int
+    agreements = None  # type: List[Agreement]
+    parent = None  # type: Optional[Agreement]
+    marketplace = None  # type: Optional[Marketplace]
 
 
 class AgreementSchema(BaseSchema):
@@ -57,49 +76,71 @@ class AgreementSchema(BaseSchema):
     description = fields.Str()
     created = fields.DateTime()
     updated = fields.DateTime()
-    owner = fields.Nested(CompanySchema, only=('id', 'name'))
-    stats = fields.Dict()
-    active = fields.Bool()
+    owner = fields.Nested(CompanySchema)
+    stats = fields.Nested(AgreementStatsSchema, allow_none=True)
+    author = fields.Nested(CompanySchema, allow_none=True)
     version = fields.Int()
+    active = fields.Bool()
     link = fields.Str()
     version_created = fields.DateTime()
     version_contracts = fields.Int()
+    agreements = fields.Nested('AgreementSchema', many=True)
+    parent = fields.Nested('AgreementSchema', only=('id', 'name'), allow_none=True)
+    marketplace = fields.Nested(MarketplaceSchema, only=('id', 'name'), allow_none=True)
 
     @post_load
     def make_object(self, data):
         return Agreement(**data)
 
 
+class Activation(BaseModel):
+    link = None  # type: Optional[str]
+    message = None  # type: str
+    date = None  # type: Optional[str]
+
+
+class ActivationSchema(BaseSchema):
+    link = fields.Str(allow_none=True)
+    message = fields.Str()
+    date = fields.DateTime(allow_none=True)
+
+    @post_load
+    def make_object(self, data):
+        return Activation(**data)
+
+
 class Contract(BaseModel):
     name = None  # type: str
-    status = None  # type: str
     version = None  # type: int
     type = None  # type: str
+    status = None  # type: str
     agreement = None  # type: Agreement
-    marketplace = None  # type: Marketplace
-    owner = None  # type: Company
+    marketplace = None  # type: Optional[Marketplace]
+    owner = None  # type: Optional[Company]
+    creator = None  # type: Company
     created = None  # type: str
     updated = None  # type: str
-    enrolled = None  # type: str
+    enrolled = None  # type: Optional[str]
     version_created = None  # type: str
-    activation = None  # type: dict
-    signee = None  # type: Company
+    activation = None  # type: Activation
+    signee = None  # type: Optional[Company]
 
 
 class ContractSchema(BaseSchema):
     name = fields.Str()
-    status = fields.Str()
     version = fields.Int()
     type = fields.Str()
+    status = fields.Str()
     agreement = fields.Nested(AgreementSchema, only=('id', 'name'))
-    marketplace = fields.Nested(MarketplaceSchema, only=('id', 'name'))
-    owner = fields.Nested(CompanySchema, only=('id', 'name'))
+    marketplace = fields.Nested(MarketplaceSchema, only=('id', 'name'), allow_none=True)
+    owner = fields.Nested(CompanySchema, only=('id', 'name'), allow_none=True)
+    creator = fields.Nested(CompanySchema, only=('id', 'name'))
     created = fields.DateTime()
     updated = fields.DateTime()
-    enrolled = fields.Str()
+    enrolled = fields.Str(allow_none=True)
     version_created = fields.DateTime()
-    activation = fields.Dict()
-    signee = fields.Nested(CompanySchema, only=('id', 'name'))
+    activation = fields.Nested(ActivationSchema)
+    signee = fields.Nested(CompanySchema, only=('id', 'name'), allow_none=True)
 
     @post_load
     def make_object(self, data):

--- a/connect/models/parameters.py
+++ b/connect/models/parameters.py
@@ -6,7 +6,7 @@ Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 
 from marshmallow import Schema, fields, post_load
-from typing import List
+from typing import List, Optional
 
 from .base import BaseModel, BaseSchema
 
@@ -14,25 +14,6 @@ from .base import BaseModel, BaseSchema
 class ValueChoice(BaseModel):
     value = None  # type: str
     label = None  # type: str
-
-
-class Constraints(BaseModel):
-    hidden = None  # type: bool
-    required = None  # type: bool
-    choices = None  # type: List[ValueChoice]
-
-
-class Param(BaseModel):
-    name = None  # type: str
-    type = None  # type: str
-    value = None  # type: str
-    value_choices = None  # type: List[ValueChoice]
-    value_error = None  # type: str
-
-    # Undocumented fields (they appear in PHP SDK)
-    title = None  # type: str
-    scope = None  # type: str
-    constraints = None  # type: Constraints
 
 
 class ValueChoiceSchema(Schema):
@@ -44,27 +25,48 @@ class ValueChoiceSchema(Schema):
         return ValueChoice(**data)
 
 
+class Constraints(BaseModel):
+    hidden = None  # type: bool
+    required = None  # type: bool
+    choices = None  # type: List[ValueChoice]
+
+
 class ConstraintsSchema(BaseSchema):
     hidden = fields.Bool()
     required = fields.Bool()
-    choices = fields.List(fields.Nested(ValueChoiceSchema))
+    choices = fields.Nested(ValueChoiceSchema, many=True)
 
     @post_load
     def make_object(self, data):
         return Constraints(**data)
 
 
-class ParamSchema(BaseSchema):
-    name = fields.Str()
-    type = fields.Str()
-    value = fields.Str()
-    value_choices = fields.List(fields.Nested(ValueChoiceSchema))
-    value_error = fields.Str()
+class Param(BaseModel):
+    name = None  # type: str
+    description = None  # type: str
+    type = None  # type: str
+    value = None  # type: str
+    value_error = None  # type: Optional[str]
+    value_choice = None  # type: Optional[List[str]]
 
     # Undocumented fields (they appear in PHP SDK)
-    title = fields.Str(required=False)
-    scope = fields.Str(required=False)
-    constraints = fields.Nested(ConstraintsSchema, required=False)
+    title = None  # type: Optional[str]
+    scope = None  # type: Optional[str]
+    constraints = None  # type: Optional[Constraints]
+
+
+class ParamSchema(BaseSchema):
+    name = fields.Str()
+    description = fields.Str()
+    type = fields.Str()
+    value = fields.Str()
+    value_error = fields.Str(allow_none=True)
+    value_choice = fields.Str(many=True, allow_none=True)
+
+    # Undocumented fields (they appear in PHP SDK)
+    title = fields.Str(allow_none=True)
+    scope = fields.Str(allow_none=True)
+    constraints = fields.Nested(ConstraintsSchema, allow_none=True)
 
     @post_load
     def make_object(self, data):

--- a/connect/models/product.py
+++ b/connect/models/product.py
@@ -135,7 +135,7 @@ class QuantityField(fields.Field):
                     return int_val if int_val == float_val else float_val
                 except ValueError:
                     raise ValueError({
-                        attr: [u'Not a valid string encoded number or "unlimited".']
+                        attr: [u'Not a valid string encoded number nor "unlimited".']
                     })
         elif isinstance(value, (int, float)):
             return value

--- a/connect/models/product.py
+++ b/connect/models/product.py
@@ -6,37 +6,127 @@ Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 
 from marshmallow import fields, post_load
-from typing import Optional
+from typing import List, Optional
 
 from .base import BaseModel, BaseSchema
+
+
+class ProductConfiguration(BaseModel):
+    suspend_resume_supported = None  # type: bool
+    requires_reseller_information = None  # type: bool
+
+
+class ProductConfigurationSchema(BaseSchema):
+    suspend_resume_supported = fields.Bool()
+    requires_reseller_information = fields.Bool()
+
+    @post_load
+    def make_object(self, data):
+        return ProductConfiguration(**data)
+
+
+class DownloadLink(BaseModel):
+    title = None  # type: str
+    url = None  # type: str
+
+
+class DownloadLinkSchema(BaseSchema):
+    title = fields.Str()
+    url = fields.Str()
+
+    @post_load
+    def make_object(self, data):
+        return DownloadLink(**data)
+
+
+class Document(BaseModel):
+    title = None  # title: str
+    url = None  # title: str
+    visible_for = None  # title: str
+
+
+class DocumentSchema(BaseSchema):
+    title = fields.Str()
+    url = fields.Str()
+    visible_for = fields.Str()
+
+    @post_load
+    def make_object(self, data):
+        return Document(**data)
+
+
+class CustomerUiSettings(BaseModel):
+    description = None  # type: str
+    getting_started = None  # type: str
+    download_links = None  # type: List[DownloadLink]
+    documents = None  # type: List[Document]
+
+
+class CustomerUiSettingsSchema(BaseSchema):
+    description = fields.Str()
+    getting_started = fields.Str()
+    download_links = fields.Nested(DownloadLinkSchema, many=True)
+    documents = fields.Nested(DocumentSchema, many=True)
+
+    @post_load
+    def make_object(self, data):
+        return CustomerUiSettings(**data)
 
 
 class Product(BaseModel):
     name = None  # type: str
     icon = None  # type: str
+    short_description = None  # type: str
+    detailed_description = None  # type: str
+    version = None  # type: int
+    configurations = None  # type: ProductConfiguration
 
 
 class ProductSchema(BaseSchema):
     name = fields.Str()
     icon = fields.Str()
+    short_description = fields.Str()
+    detailed_description = fields.Str()
+    version = fields.Int()
+    configurations = fields.Nested(ProductConfigurationSchema)
 
     @post_load
     def make_object(self, data):
         return Product(**data)
 
 
+class Renewal(BaseModel):
+    from_ = None  # type: str
+    to = None  # type: str
+    period_delta = None  # type: int
+    period_uom = None  # type: str
+
+
+class RenewalSchema(BaseSchema):
+    from_ = fields.DateTime(attribute='from')
+    to = fields.DateTime()
+    period_delta = fields.Int()
+    period_uom = fields.Str()
+
+    @post_load
+    def make_object(self, data):
+        return Renewal(**data)
+
+
 class Item(BaseModel):
-    global_id = None  # type: str
     mpn = None  # type: str
-    old_quantity = None  # type: Optional[int]
     quantity = None  # type: Optional[int]
+    old_quantity = None  # type: Optional[int]
+    renewal = None  # type: Optional[Renewal]
+    global_id = None  # type: str
 
 
 class ItemSchema(BaseSchema):
-    global_id = fields.Str()
     mpn = fields.Str()
-    old_quantity = fields.Str()
     quantity = fields.Str()
+    old_quantity = fields.Str(allow_none=True)
+    renewal = fields.Nested(RenewalSchema, allow_none=True)
+    global_id = fields.Str()
 
     @post_load
     def make_object(self, data):

--- a/connect/models/product.py
+++ b/connect/models/product.py
@@ -6,6 +6,7 @@ Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 
 from marshmallow import fields, post_load
+from typing import Union
 
 from .base import BaseModel, BaseSchema
 
@@ -28,15 +29,20 @@ class Item(BaseModel):
     global_id = None  # type: str
     mpn = None  # type: str
     old_quantity = None  # type: int
-    quantity = None  # type: int
+    quantity = None  # type: Union[int, str]
 
 
 class ItemSchema(BaseSchema):
     global_id = fields.Str()
     mpn = fields.Str()
     old_quantity = fields.Integer()
-    quantity = fields.Integer()
+    quantity = fields.Str()
 
     @post_load
     def make_object(self, data):
+        # If quantity string contains a number, convert to int
+        if 'quantity' in data:
+            quantity = data['quantity']
+            if quantity.isdigit() or (quantity.startswith('-') and quantity[1:].isdigit()):
+                data['quantity'] = int(quantity)
         return Item(**data)

--- a/connect/models/product.py
+++ b/connect/models/product.py
@@ -29,7 +29,7 @@ class Item(BaseModel):
     global_id = None  # type: str
     mpn = None  # type: str
     old_quantity = None  # type: int
-    quantity = None  # type: Union[int, str]
+    quantity = None  # type: Union[int, None]
 
 
 class ItemSchema(BaseSchema):
@@ -45,4 +45,6 @@ class ItemSchema(BaseSchema):
             quantity = data['quantity']
             if quantity.isdigit() or (quantity.startswith('-') and quantity[1:].isdigit()):
                 data['quantity'] = int(quantity)
+            else:
+                data['quantity'] = None
         return Item(**data)

--- a/connect/models/product.py
+++ b/connect/models/product.py
@@ -28,23 +28,24 @@ class ProductSchema(BaseSchema):
 class Item(BaseModel):
     global_id = None  # type: str
     mpn = None  # type: str
-    old_quantity = None  # type: int
+    old_quantity = None  # type: Union[int, None]
     quantity = None  # type: Union[int, None]
 
 
 class ItemSchema(BaseSchema):
     global_id = fields.Str()
     mpn = fields.Str()
-    old_quantity = fields.Integer()
+    old_quantity = fields.Str()
     quantity = fields.Str()
 
     @post_load
     def make_object(self, data):
-        # If quantity string contains a number, convert to int
-        if 'quantity' in data:
-            quantity = data['quantity']
-            if quantity.isdigit() or (quantity.startswith('-') and quantity[1:].isdigit()):
-                data['quantity'] = int(quantity)
-            else:
-                data['quantity'] = None
+        params = ('quantity', 'old_quantity')
+        for param in params:
+            if param in data:
+                value = data[param]
+                if value.isdigit() or (value.startswith('-') and value[1:].isdigit()):
+                    data[param] = int(value)
+                else:
+                    data[param] = None
         return Item(**data)

--- a/connect/models/product.py
+++ b/connect/models/product.py
@@ -6,7 +6,7 @@ Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 
 from marshmallow import fields, post_load
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from .base import BaseModel, BaseSchema
 
@@ -115,8 +115,8 @@ class RenewalSchema(BaseSchema):
 
 class Item(BaseModel):
     mpn = None  # type: str
-    quantity = None  # type: Optional[int]
-    old_quantity = None  # type: Optional[int]
+    quantity = None  # type: Union[int,float]
+    old_quantity = None  # type: Union[int,float,None]
     renewal = None  # type: Optional[Renewal]
     global_id = None  # type: str
 
@@ -134,7 +134,9 @@ class ItemSchema(BaseSchema):
         for param in params:
             if param in data:
                 if data[param] != 'unlimited':
-                    data[param] = int(data[param])
+                    float_val = float(data[param])
+                    int_val = int(float_val)
+                    data[param] = int_val if float_val == int_val else float_val
                 else:
-                    data[param] = None
+                    data[param] = -1
         return Item(**data)

--- a/connect/models/product.py
+++ b/connect/models/product.py
@@ -5,8 +5,10 @@ This file is part of the Ingram Micro Cloud Blue Connect SDK.
 Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 
-from marshmallow import fields, post_load
 from typing import List, Optional, Union
+
+from marshmallow import fields, post_load
+import six
 
 from .base import BaseModel, BaseSchema
 
@@ -121,22 +123,33 @@ class Item(BaseModel):
     global_id = None  # type: str
 
 
+class QuantityField(fields.Field):
+    def _deserialize(self, value, attr, obj, **kwargs):
+        if isinstance(value, six.string_types):
+            if value == 'unlimited':
+                return -1
+            else:
+                try:
+                    float_val = float(value)
+                    int_val = int(float_val)
+                    return int_val if int_val == float_val else float_val
+                except ValueError:
+                    raise ValueError({
+                        attr: [u'Not a valid string encoded number or "unlimited".']
+                    })
+        elif isinstance(value, (int, float)):
+            return value
+        else:
+            raise ValueError({attr: [u'Not a valid int, float or string.']})
+
+
 class ItemSchema(BaseSchema):
     mpn = fields.Str()
-    quantity = fields.Str()
-    old_quantity = fields.Str(allow_none=True)
+    quantity = QuantityField()
+    old_quantity = QuantityField(allow_none=True)
     renewal = fields.Nested(RenewalSchema, allow_none=True)
     global_id = fields.Str()
 
     @post_load
     def make_object(self, data):
-        params = ('quantity', 'old_quantity')
-        for param in params:
-            if param in data:
-                if data[param] != 'unlimited':
-                    float_val = float(data[param])
-                    int_val = int(float_val)
-                    data[param] = int_val if float_val == int_val else float_val
-                else:
-                    data[param] = -1
         return Item(**data)

--- a/connect/models/product.py
+++ b/connect/models/product.py
@@ -6,7 +6,7 @@ Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 
 from marshmallow import fields, post_load
-from typing import Union
+from typing import Optional
 
 from .base import BaseModel, BaseSchema
 
@@ -28,8 +28,8 @@ class ProductSchema(BaseSchema):
 class Item(BaseModel):
     global_id = None  # type: str
     mpn = None  # type: str
-    old_quantity = None  # type: Union[int, None]
-    quantity = None  # type: Union[int, None]
+    old_quantity = None  # type: Optional[int]
+    quantity = None  # type: Optional[int]
 
 
 class ItemSchema(BaseSchema):
@@ -43,9 +43,8 @@ class ItemSchema(BaseSchema):
         params = ('quantity', 'old_quantity')
         for param in params:
             if param in data:
-                value = data[param]
-                if value.isdigit() or (value.startswith('-') and value[1:].isdigit()):
-                    data[param] = int(value)
+                if data[param] != 'unlimited':
+                    data[param] = int(data[param])
                 else:
                     data[param] = None
         return Item(**data)

--- a/connect/models/tier_config.py
+++ b/connect/models/tier_config.py
@@ -9,7 +9,7 @@ from typing import Optional, List
 
 from connect.models import Param, ParamSchema
 from connect.models.base import BaseModel, BaseSchema
-from connect.models.company import Company, CompanySchema
+from connect.models.company import User, UserSchema
 from connect.models.connection import Connection, ConnectionSchema
 from connect.models.contact import ContactInfo, ContactInfoSchema
 from connect.models.event import EventsSchema, Events
@@ -92,7 +92,7 @@ class TierConfigRequest(BaseModel):
     configuration = None  # type: TierConfig
     events = None  # type: Optional[Events]
     params = None  # type: List[Param]
-    assignee = None  # type: Optional[Company]
+    assignee = None  # type: Optional[User]
     template = None  # type: Optional[Template]
     reason = None  # type: Optional[str]
     activation = None  # type: Optional[Activation]
@@ -112,7 +112,7 @@ class TierConfigRequestSchema(BaseSchema):
     configuration = fields.Nested(TierConfigSchema)
     events = fields.Nested(EventsSchema, allow_none=True)
     params = fields.Nested(ParamSchema, many=True)
-    assignee = fields.Nested(CompanySchema, allow_none=True)
+    assignee = fields.Nested(UserSchema, allow_none=True)
     template = fields.Nested(TemplateSchema, allow_none=True)
     reason = fields.Str(allow_none=True)
     activation = fields.Nested(ActivationSchema, allow_none=True)

--- a/connect/resource/base.py
+++ b/connect/resource/base.py
@@ -157,6 +157,6 @@ class BaseResource(object):
         if error:
             raise TypeError(
                 'Invalid structure for initialization of `{}`. \n'
-                'Error: {}. \nServer Response: {}'.format(type(self).__name__, error, response),
+                'Error: {}. \nServer Response: {}'.format(type(schema).__name__, error, response),
             )
         return objects

--- a/requirements/sdk.txt
+++ b/requirements/sdk.txt
@@ -1,3 +1,4 @@
 marshmallow==2.18.0
 openpyxl==2.5.14
 requests==2.21.0
+six==1.12.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,5 +2,4 @@ flake8==3.7.5
 pytest==4.2.0
 pytest-cov==2.6.1
 mock==2.0.0
-six==1.12.0
 -r sdk.txt

--- a/tests/test_tier_config.py
+++ b/tests/test_tier_config.py
@@ -14,7 +14,7 @@ from typing import Union
 from connect import TierConfigAutomation
 from connect.models import Param, ActivationTileResponse, ActivationTemplateResponse
 from connect.models.base import BaseModel
-from connect.models.company import Company
+from connect.models.company import Company, User
 from connect.models.connection import Connection
 from connect.models.event import EventInfo
 from connect.models.exception import FulfillmentInquire, FulfillmentFail, Skip
@@ -101,7 +101,7 @@ def test_create_resource():
     assert isinstance(events.updated, EventInfo)
     assert isinstance(events.updated.at, datetime)
     assert str(events.updated.at) == '2018-11-21 11:10:29'
-    assert isinstance(events.updated.by, Company)
+    assert isinstance(events.updated.by, User)
     assert events.updated.by.id == 'PA-000-000'
     assert events.updated.by.name == 'Username'
 
@@ -130,13 +130,13 @@ def test_create_resource():
     assert isinstance(events.inquired, EventInfo)
     assert isinstance(events.inquired.at, datetime)
     assert str(events.inquired.at) == '2018-11-21 11:10:29'
-    assert isinstance(events.inquired.by, Company)
+    assert isinstance(events.inquired.by, User)
     assert events.inquired.by.id == 'PA-000-000'
     assert events.inquired.by.name == 'Username'
     assert isinstance(events.pended, EventInfo)
     assert isinstance(events.pended.at, datetime)
     assert str(events.pended.at) == '2018-11-21 11:10:29'
-    assert isinstance(events.pended.by, Company)
+    assert isinstance(events.pended.by, User)
     assert events.pended.by.id == 'PA-000-001'
     assert events.pended.by.name == 'Username1'
     assert not events.validated
@@ -150,7 +150,7 @@ def test_create_resource():
     assert request.params[0].value == 'param_a_value'
 
     assignee = request.assignee
-    assert isinstance(assignee, Company)
+    assert isinstance(assignee, User)
     assert assignee.id == 'PA-000-000'
     assert assignee.name == 'Username'
 

--- a/tests/test_tier_config.py
+++ b/tests/test_tier_config.py
@@ -5,6 +5,7 @@ This file is part of the Ingram Micro Cloud Blue Connect SDK.
 Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 """
 import os
+from datetime import datetime
 
 import pytest
 from mock import MagicMock, patch
@@ -15,11 +16,12 @@ from connect.models import Param, ActivationTileResponse, ActivationTemplateResp
 from connect.models.base import BaseModel
 from connect.models.company import Company
 from connect.models.connection import Connection
+from connect.models.event import EventInfo
 from connect.models.exception import FulfillmentInquire, FulfillmentFail, Skip
 from connect.models.hub import Hub
 from connect.models.product import Product
 from connect.models.tier_config import TierConfigRequest, TierConfig, Events, Template, \
-    Activation, EventInfo, Account
+    Activation, Account
 from .response import Response
 
 
@@ -90,13 +92,15 @@ def test_create_resource():
     events = configuration.events
     assert isinstance(events, Events)
     assert isinstance(events.created, EventInfo)
-    assert events.created.at == '2018-11-21T11:10:29+00:00'
+    assert isinstance(events.created.at, datetime)
+    assert str(events.created.at) == '2018-11-21 11:10:29'
     assert not events.created.by
     assert not events.inquired
     assert not events.pended
     assert not events.validated
     assert isinstance(events.updated, EventInfo)
-    assert events.updated.at == '2018-11-21T11:10:29+00:00'
+    assert isinstance(events.updated.at, datetime)
+    assert str(events.updated.at) == '2018-11-21 11:10:29'
     assert isinstance(events.updated.by, Company)
     assert events.updated.by.id == 'PA-000-000'
     assert events.updated.by.name == 'Username'
@@ -120,15 +124,18 @@ def test_create_resource():
     events = request.events
     assert isinstance(events, Events)
     assert isinstance(events.created, EventInfo)
-    assert events.created.at == '2018-11-21T11:10:29+00:00'
+    assert isinstance(events.created.at, datetime)
+    assert str(events.created.at) == '2018-11-21 11:10:29'
     assert not events.created.by
     assert isinstance(events.inquired, EventInfo)
-    assert events.inquired.at == '2018-11-21T11:10:29+00:00'
+    assert isinstance(events.inquired.at, datetime)
+    assert str(events.inquired.at) == '2018-11-21 11:10:29'
     assert isinstance(events.inquired.by, Company)
     assert events.inquired.by.id == 'PA-000-000'
     assert events.inquired.by.name == 'Username'
     assert isinstance(events.pended, EventInfo)
-    assert events.pended.at == '2018-11-21T11:10:29+00:00'
+    assert isinstance(events.pended.at, datetime)
+    assert str(events.pended.at) == '2018-11-21 11:10:29'
     assert isinstance(events.pended.by, Company)
     assert events.pended.by.id == 'PA-000-001'
     assert events.pended.by.name == 'Username1'


### PR DESCRIPTION
Fixed crash parsing `Item.quantity` when it contains the string `'unlimited'`.

Now, `Item.quantity` can contain either an `int` or `float`. If `quantity` is of numeric type or a string encoded number, it is stored as an int or float, depending on whether the number has decimals. If the string contains `'unlimited'`, -1 is stored.