### PR TITLE
CPS-17-refactor-exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ pip install connect-sdk
 from connect import FulfillmentAutomation, TierConfigAutomation
 from connect.logger import logger
 from connect.models import ActivationTemplateResponse, ActivationTileResponse
-from connect.models.exception import FulfillmentFail, FulfillmentInquire, Skip
+from connect.models.exception import FailRequest, InquireRequest, SkipRequest
 
 
 class ExampleRequestProcessor(FulfillmentAutomation):
@@ -56,13 +56,13 @@ class ExampleRequestProcessor(FulfillmentAutomation):
         if request.type == 'purchase':
             for item in request.asset.items:
                 if item.quantity > 100000:
-                    raise FulfillmentFail(
+                    raise FailRequest(
                         message='Is Not possible to purchase product')
 
             for param in request.asset.params:
                 if param.name == 'email' and not param.value:
                     param.value_error = 'Email address has not been provided, please provide one'
-                    raise FulfillmentInquire(params=[param])
+                    raise InquireRequest(params=[param])
 
             # Approve by ActivationTile
             return ActivationTileResponse('\n  # Welcome to Fallball!\n\nYes, '
@@ -77,11 +77,10 @@ class ExampleRequestProcessor(FulfillmentAutomation):
 
         elif request.type == 'change':
             # Fail
-            raise FulfillmentFail()
+            raise FailRequest()
         else:
             # Skip request
-            raise Skip()
-
+            raise SkipRequest()
 
 class ExampleTierConfigProcessor(TierConfigAutomation):
     def process_request(self, request):

--- a/connect/models/__init__.py
+++ b/connect/models/__init__.py
@@ -10,7 +10,7 @@ from .base import BaseSchema
 from .fulfillment import FulfillmentSchema
 from .parameters import Param, ParamSchema
 from .product import Item, ItemSchema
-from .server_error import ServerErrorSchema
+from .server_error_response import ServerErrorResponseSchema
 
 __all__ = [
     'ActivationTemplateResponse',
@@ -21,5 +21,5 @@ __all__ = [
     'ItemSchema',
     'Param',
     'ParamSchema',
-    'ServerErrorSchema',
+    'ServerErrorResponseSchema',
 ]

--- a/connect/models/exception.py
+++ b/connect/models/exception.py
@@ -26,25 +26,25 @@ class Message(Exception):
         return str(self)
 
 
-class FulfillmentFail(Message):
+class FailRequest(Message):
     def __init__(self, message=''):
         # type: (str) -> None
-        super(FulfillmentFail, self).__init__(message or 'Request failed', 'fail')
+        super(FailRequest, self).__init__(message or 'Request failed', 'fail')
 
 
-class FulfillmentInquire(Message):
+class InquireRequest(Message):
     params = None  # type: List[Param]
 
     def __init__(self, message='', params=None):
         # type: (str, List[Param]) -> None
-        super(FulfillmentInquire, self).__init__(message or 'Correct user input required', 'inquire')
+        super(InquireRequest, self).__init__(message or 'Correct user input required', 'inquire')
         self.params = params or []
 
 
-class Skip(Message):
+class SkipRequest(Message):
     def __init__(self, message=''):
         # type: (str) -> None
-        super(Skip, self).__init__(message or 'Request skipped', 'skip')
+        super(SkipRequest, self).__init__(message or 'Request skipped', 'skip')
 
 
 class ServerError(Exception):
@@ -107,3 +107,19 @@ class FileRetrievalError(Message):
     def __init__(self, message):
         # type: (str) -> None
         super(FileRetrievalError, self).__init__(message, 'fileretrieval')
+
+
+# These exist only for backwards compatibility
+# TODO: Add deprecation warning
+
+
+class FulfillmentFail(FailRequest):
+    pass
+
+
+class FulfillmentInquire(InquireRequest):
+    pass
+
+
+class Skip(SkipRequest):
+    pass

--- a/connect/models/exception.py
+++ b/connect/models/exception.py
@@ -7,7 +7,7 @@ Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 from typing import List, Dict, Any, Optional
 
 from connect.models import Param
-from .server_error import ServerError
+from .server_error_response import ServerErrorResponse
 
 
 class Message(Exception):
@@ -16,36 +16,43 @@ class Message(Exception):
 
     def __init__(self, message='', code='', obj=None):
         # type: (str, str, object) -> None
-        self.message = message
+        super(Message, self).__init__(message)
         self.code = code
         self.obj = obj
 
+    @property
+    def message(self):
+        # type: () -> str
+        return str(self)
+
 
 class FulfillmentFail(Message):
-    def __init__(self, *args, **kwargs):
-        # type: (*any, **any) -> None
-        super(FulfillmentFail, self).__init__(*args, **kwargs)
-        self.message = self.message or 'Request failed'
-        self.code = 'fail'
+    def __init__(self, message=''):
+        # type: (str) -> None
+        super(FulfillmentFail, self).__init__(message or 'Request failed', 'fail')
 
 
 class FulfillmentInquire(Message):
     params = None  # type: List[Param]
 
-    def __init__(self, *args, **kwargs):
-        # type: (*any, **any) -> None
-        super(FulfillmentInquire, self).__init__(*args, **kwargs)
-        self.message = self.message or 'Correct user input required'
-        self.code = 'inquire'
-        self.params = kwargs.get('params', [])
+    def __init__(self, message='', params=None):
+        # type: (str, List[Param]) -> None
+        super(FulfillmentInquire, self).__init__(message or 'Correct user input required', 'inquire')
+        self.params = params or []
 
 
 class Skip(Message):
-    def __init__(self, *args, **kwargs):
-        # type: (*any, **any) -> None
-        super(Skip, self).__init__(*args, **kwargs)
-        self.message = self.message or 'Request skipped'
-        self.code = 'skip'
+    def __init__(self, message=''):
+        # type: (str) -> None
+        super(Skip, self).__init__(message or 'Request skipped', 'skip')
+
+
+class ServerError(Exception):
+    message = 'Server error'  # type: str
+
+    def __init__(self, error):
+        # type: (ServerErrorResponse) -> None
+        super(ServerError, self).__init__(str(error), error.error_code)
 
 
 class UsageFileAction(Message):
@@ -88,24 +95,6 @@ class SubmitUsageFile(UsageFileAction):
             'Usage File Submited',
             'submit',
             {'rejection_note': rejection_note})
-
-
-class ServerErrorException(Exception):
-    message = 'Server error'  # type: str
-
-    def __init__(self, error=None, *args, **kwargs):
-        # type: (ServerError, *any, **any) -> None
-
-        if error and isinstance(error, ServerError):
-            self.message = str({
-                "error_code": error.error_code,
-                "params": kwargs.get('params', []),
-                "errors": error.errors,
-            })
-        else:
-            self.message = self.__class__.message
-
-        super(ServerErrorException, self).__init__(self.message, *args)
 
 
 class FileCreationError(Message):

--- a/connect/models/server_error_response.py
+++ b/connect/models/server_error_response.py
@@ -11,17 +11,24 @@ from typing import List
 from .base import BaseModel
 
 
-class ServerError(BaseModel):
+class ServerErrorResponse(BaseModel):
     error_code = None  # type: str
     params = None  # type: dict
     errors = None  # type: List[str]
 
+    def __str__(self):
+        return str({
+            'error_code': self.error_code,
+            'params': self.params,
+            'errors': self.errors,
+        })
 
-class ServerErrorSchema(Schema):
+
+class ServerErrorResponseSchema(Schema):
     error_code = fields.Str()
     params = fields.Dict()
     errors = fields.List(fields.Str())
 
     @post_load
     def make_object(self, data):
-        return ServerError(**data)
+        return ServerErrorResponse(**data)

--- a/connect/resource/base.py
+++ b/connect/resource/base.py
@@ -12,8 +12,8 @@ from requests import compat
 
 from connect.config import Config
 from connect.logger import function_log, logger
-from connect.models import BaseSchema, ServerErrorSchema
-from connect.models.exception import ServerErrorException
+from connect.models import BaseSchema, ServerErrorResponseSchema
+from connect.models.exception import ServerError
 
 
 class ApiClient(object):
@@ -102,9 +102,9 @@ class ApiClient(object):
                     'Response status - {}'.format(attr, response.status_code),
                 )
         if not response.ok:
-            data, error = ServerErrorSchema().loads(response.content)
+            data, error = ServerErrorResponseSchema().loads(response.content)
             if data:
-                raise ServerErrorException(data)
+                raise ServerError(data)
 
         return response.content, response.status_code
 

--- a/connect/resource/fulfillment_automation.py
+++ b/connect/resource/fulfillment_automation.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 
 from connect.logger import logger, function_log
 from connect.models import ActivationTemplateResponse, ActivationTileResponse, Param
-from connect.models.exception import FulfillmentFail, FulfillmentInquire, Skip
+from connect.models.exception import FailRequest, InquireRequest, SkipRequest
 from connect.models.fulfillment import Fulfillment, FulfillmentSchema
 from connect.models.tier_config import TierConfig, TierConfigRequestSchema
 from .automation import AutomationResource
@@ -50,14 +50,14 @@ class FulfillmentAutomation(AutomationResource):
 
             return self.approve(request.id, params)
 
-        except FulfillmentInquire as inquire:
+        except InquireRequest as inquire:
             self.update_parameters(request.id, inquire.params)
             return self.inquire(request.id)
 
-        except FulfillmentFail as fail:
+        except FailRequest as fail:
             return self.fail(request.id, reason=fail.message)
 
-        except Skip as skip:
+        except SkipRequest as skip:
             return skip.code
 
     def get_tier_config(self, tier_id, product_id):

--- a/connect/resource/tier_config_automation.py
+++ b/connect/resource/tier_config_automation.py
@@ -10,7 +10,7 @@ from typing import List
 
 from connect.logger import logger, function_log
 from connect.models import ActivationTemplateResponse, ActivationTileResponse, Param
-from connect.models.exception import FulfillmentFail, FulfillmentInquire, Skip
+from connect.models.exception import FailRequest, InquireRequest, SkipRequest
 from connect.models.tier_config import TierConfigRequest, TierConfigRequestSchema
 from .automation import AutomationResource
 
@@ -43,14 +43,14 @@ class TierConfigAutomation(AutomationResource):
 
             self.approve(request.id, params)
 
-        except FulfillmentInquire as inquire:
+        except InquireRequest as inquire:
             self.update_parameters(request.id, inquire.params)
             return self.inquire(request.id)
 
-        except FulfillmentFail as fail:
+        except FailRequest as fail:
             return self.fail(request.id, reason=fail.message)
 
-        except Skip as skip:
+        except SkipRequest as skip:
             return skip.code
 
         return ''

--- a/connect/resource/usage_file_automation.py
+++ b/connect/resource/usage_file_automation.py
@@ -32,8 +32,8 @@ class UsageFileAutomation(AutomationResource):
             result = self.process_request(request)
 
             # Report that expected exception was not raised
-            processing_result = 'UsageFileAutomation.process_request returned {} ' \
-                                'while is expected to raise UsageFileAction or SkipRequest exception' \
+            processing_result = 'UsageFileAutomation.process_request returned {} while ' \
+                                'is expected to raise UsageFileAction or SkipRequest exception' \
                 .format(str(result))
             logger.warning(processing_result)
             raise UserWarning(processing_result)

--- a/connect/resource/usage_file_automation.py
+++ b/connect/resource/usage_file_automation.py
@@ -8,7 +8,7 @@ from abc import ABCMeta
 
 from connect.logger import logger
 from connect.models.base import BaseModel
-from connect.models.exception import UsageFileAction, Skip
+from connect.models.exception import UsageFileAction, SkipRequest
 from connect.models.usage import FileSchema, File
 from connect.resource import AutomationResource
 
@@ -33,7 +33,7 @@ class UsageFileAutomation(AutomationResource):
 
             # Report that expected exception was not raised
             processing_result = 'UsageFileAutomation.process_request returned {} ' \
-                                'while is expected to raise UsageFileAction or Skip exception' \
+                                'while is expected to raise UsageFileAction or SkipRequest exception' \
                 .format(str(result))
             logger.warning(processing_result)
             raise UserWarning(processing_result)
@@ -48,7 +48,7 @@ class UsageFileAutomation(AutomationResource):
             processing_result = usage.code
 
         # Catch skip
-        except Skip:
+        except SkipRequest:
             processing_result = 'skip'
 
         logger.info('Finished processing of usage file with ID {} with result {}'

--- a/example/example.py
+++ b/example/example.py
@@ -10,7 +10,7 @@ from connect import FulfillmentAutomation, TierConfigAutomation
 from connect.config import Config
 from connect.logger import logger
 from connect.models import ActivationTemplateResponse, ActivationTileResponse
-from connect.models.exception import FulfillmentFail, FulfillmentInquire, Skip
+from connect.models.exception import FailRequest, InquireRequest, SkipRequest
 from connect.models.fulfillment import Fulfillment
 from connect.models.tier_config import TierConfigRequest
 
@@ -35,13 +35,13 @@ class ExampleRequestProcessor(FulfillmentAutomation):
         if request.type == 'purchase':
             for item in request.asset.items:
                 if item.quantity > 100000:
-                    raise FulfillmentFail(
+                    raise FailRequest(
                         message='Is Not possible to purchase product')
 
             for param in request.asset.params:
                 if param.name == 'email' and not param.value:
                     param.value_error = 'Email address has not been provided, please provide one'
-                    raise FulfillmentInquire(params=[param])
+                    raise InquireRequest(params=[param])
 
             # Approve by ActivationTile
             return ActivationTileResponse('\n  # Welcome to Fallball!\n\nYes, you decided '
@@ -57,10 +57,10 @@ class ExampleRequestProcessor(FulfillmentAutomation):
 
         elif request.type == 'change':
             # Fail
-            raise FulfillmentFail()
+            raise FailRequest()
         else:
             # Skip request
-            raise Skip()
+            raise SkipRequest()
 
 
 class ExampleTierConfigProcessor(TierConfigAutomation):

--- a/tests/test_tier_config.py
+++ b/tests/test_tier_config.py
@@ -16,7 +16,7 @@ from connect.models.base import BaseModel
 from connect.models.company import Company
 from connect.models.connection import Connection
 from connect.models.event import EventInfo
-from connect.models.exception import FulfillmentInquire, FulfillmentFail, Skip
+from connect.models.exception import InquireRequest, FailRequest, SkipRequest
 from connect.models.hub import Hub
 from connect.models.product import Product
 from connect.models.tier_config import TierConfigRequest, TierConfig, Events, Template, \
@@ -195,7 +195,7 @@ def test_process_with_activation_template():
 @patch('requests.post', MagicMock(return_value=_get_response_ok()))
 @patch('requests.put', MagicMock(return_value=_get_response_ok()))
 def test_process_raise_inquire():
-    automation = TierConfigAutomationHelper(exception_class=FulfillmentInquire)
+    automation = TierConfigAutomationHelper(exception_class=InquireRequest)
     automation.process()
 
 
@@ -203,7 +203,7 @@ def test_process_raise_inquire():
 @patch('requests.post', MagicMock(return_value=_get_response_ok()))
 @patch('requests.put', MagicMock(return_value=_get_response_ok()))
 def test_process_raise_fail():
-    automation = TierConfigAutomationHelper(exception_class=FulfillmentFail)
+    automation = TierConfigAutomationHelper(exception_class=FailRequest)
     automation.process()
 
 
@@ -211,7 +211,7 @@ def test_process_raise_fail():
 @patch('requests.post', MagicMock(return_value=_get_response_ok()))
 @patch('requests.put', MagicMock(return_value=_get_response_ok()))
 def test_process_raise_skip():
-    automation = TierConfigAutomationHelper(exception_class=Skip)
+    automation = TierConfigAutomationHelper(exception_class=SkipRequest)
     automation.process()
 
 

--- a/tests/test_usage_file.py
+++ b/tests/test_usage_file.py
@@ -11,7 +11,7 @@ from mock import patch, MagicMock
 
 from connect.models import usage
 from connect.models.company import Company
-from connect.models.exception import Skip, AcceptUsageFile, CloseUsageFile, DeleteUsageFile, \
+from connect.models.exception import SkipRequest, AcceptUsageFile, CloseUsageFile, DeleteUsageFile, \
     RejectUsageFile, SubmitUsageFile
 from connect.models.marketplace import Contract, Marketplace
 from connect.models.product import Product
@@ -130,4 +130,4 @@ class UsageFileAutomationTester(UsageFileAutomation):
         elif request.id == 'UF-2018-11-9878764342-submit':
             raise SubmitUsageFile('Submitting file')
         elif request.id == 'UF-2018-11-9878764342-skip':
-            raise Skip('Skipping')
+            raise SkipRequest('Skipping')

--- a/tests/test_usage_file.py
+++ b/tests/test_usage_file.py
@@ -11,8 +11,8 @@ from mock import patch, MagicMock
 
 from connect.models import usage
 from connect.models.company import Company
-from connect.models.exception import SkipRequest, AcceptUsageFile, CloseUsageFile, DeleteUsageFile, \
-    RejectUsageFile, SubmitUsageFile
+from connect.models.exception import SkipRequest, AcceptUsageFile, CloseUsageFile, \
+    DeleteUsageFile, RejectUsageFile, SubmitUsageFile
 from connect.models.marketplace import Contract, Marketplace
 from connect.models.product import Product
 from connect.models.usage import Records


### PR DESCRIPTION
Refactored exceptions to have more generic names:

- FulfillmentFail → FailRequest
- FulfillmentInquire → InquireRequest
- Skip → SkipRequest
- ServerErrorException → ServerError

This allows for these classes to have meaningful names when used outside of the Fulfillment API, and be consistent with package and language standards. The old exceptions are still available for backwards compatibility.