### PR TITLE
CPS-8-get-tier-config (more)

### DIFF
--- a/connect/models/tier_config.py
+++ b/connect/models/tier_config.py
@@ -35,7 +35,7 @@ class TierAccount(BaseModel):
     """ (str|None) Only in case of filtering by this field. """
 
     @classmethod
-    def get_config(cls, account_id, product_id, config=None):
+    def get_config(cls, account_id, product_id=None, config=None):
         """
         Gets the specified TierConfig for the specified account. For example, to get Tier 1
         configuration data for one request we can do: ::
@@ -43,7 +43,7 @@ class TierAccount(BaseModel):
             TierAccount.get_config(request.asset.tiers.tier1.id, request.asset.product.id)
 
         :param str account_id: TierAccount id (an id beginning with ``TA-``).
-        :param str product_id: Id of the product.
+        :param Optional[str] product_id: Optional id of the product.
         :param Config config: Config to use, or ``None`` to use environment config (default).
         :return: The requested TierConfig, or ``None`` if it was not found.
         :rtype: Optional[TierConfig]
@@ -52,7 +52,7 @@ class TierAccount(BaseModel):
         return request.configuration if request else None
 
     @classmethod
-    def get_request(cls, account_id, product_id, config=None):
+    def get_request(cls, account_id, product_id=None, config=None):
         """
         Gets the specified TierConfigRequest for the specified account. For example, to get Tier 1
         configuration request for one request we can do: ::
@@ -60,19 +60,22 @@ class TierAccount(BaseModel):
             TierAccount.get_request(request.asset.tiers.tier1.id, request.asset.product.id)
 
         :param str account_id: TierAccount id (an id beginning with ``TA-``).
-        :param str product_id: Id of the product.
+        :param Optional[str] product_id: Optional id of the product.
         :param Config config: Config to use, or ``None`` to use environment config (default).
         :return: The requested TierConfigRequest, or ``None`` if it was not found.
         :rtype: Optional[TierConfigRequest]
         """
         from connect.resources.base import ApiClient
 
+        params = {
+            'status': 'approved',
+            'configuration__account__id': account_id,
+        }
+        if product_id:
+            params['configuration__product__id'] = product_id
+
         response, _ = ApiClient(config, base_path='tier/config-requests').get(
-            params={
-                'status': 'approved',
-                'configuration.product.id': product_id,
-                'configuration.account.id': account_id,
-            }
+            params=params
         )
         objects = TierConfigRequest.deserialize(response)
 
@@ -143,7 +146,7 @@ class TierConfig(BaseModel):
     """ (:py:class:`.BaseModel` | None) Reference to TCR. """
 
     @classmethod
-    def get(cls, tier_id, product_id, config=None):
+    def get(cls, tier_id, product_id=None, config=None):
         """
         Gets the specified TierConfig by its id, which must have been approved. For example: ::
 
@@ -153,19 +156,22 @@ class TierConfig(BaseModel):
         asset's ``tiers`` attribute), use ``TierAccount.get_config`` instead.
 
         :param str tier_id: Id of the requested TierConfig (an id beginning with ``TC-``).
-        :param str product_id: Id of the product.
+        :param Optional[str] product_id: Optional id of the product.
         :param Config config: Config to use, or ``None`` to use environment config (default).
         :return: The requested TierConfig, or ``None`` if it was not found.
         :rtype: Optional[TierConfig]
         """
         from connect.resources.base import ApiClient
 
+        params = {
+            'status': 'approved',
+            'configuration__id': tier_id,
+        }
+        if product_id:
+            params['configuration__product__id'] = product_id
+
         response, _ = ApiClient(config, base_path='tier/config-requests').get(
-            params={
-                'status': 'approved',
-                'configuration.product.id': product_id,
-                'configuration.id': tier_id,
-            }
+            params=params
         )
         objects = TierConfigRequest.deserialize(response)
 
@@ -225,7 +231,7 @@ class TierConfigRequest(BaseModel):
     """ (str) TCR pending notes. Notes can be modified only in Pending state. """
 
     @classmethod
-    def get(cls, request_id, product_id, config=None):
+    def get(cls, request_id, product_id=None, config=None):
         """
         Gets the specified TierConfigRequest by its id, which must have been approved.
         For example: ::
@@ -237,19 +243,22 @@ class TierConfigRequest(BaseModel):
 
         :param str request_id: Id of the requested TierConfigRequest
             (an id beginning with ``TCR-``).
-        :param str product_id: Id of the product.
+        :param Optional[str] product_id: Optional id of the product.
         :param Config config: Config to use, or ``None`` to use environment config (default).
         :return: The requested TierConfigRequest, or ``None`` if it was not found.
         :rtype: Optional[TierConfigRequest]
         """
         from connect.resources.base import ApiClient
 
+        params = {
+            'status': 'approved',
+        }
+        if product_id:
+            params['configuration__product__id'] = product_id
+
         response, _ = ApiClient(config, base_path='tier/config-requests').get(
             path=request_id,
-            params={
-                'status': 'approved',
-                'configuration.product.id': product_id
-            }
+            params=params
         )
         objects = TierConfigRequest.deserialize(response)
 

--- a/connect/models/tier_config.py
+++ b/connect/models/tier_config.py
@@ -95,46 +95,6 @@ class TierConfig(BaseModel):
     open_request = None  # type: Optional[BaseModel]
     """ (:py:class:`.BaseModel` | None) Reference to TCR. """
 
-    @classmethod
-    def get(cls, account_id=None, product_id=None, tier_id=None, config=None, **custom_filters):
-        """ Gets the specified TierConfig (which by default must have been approved).
-        For example: ::
-
-            TierConfig.get(account_id=request.asset.tiers.tier1.id)
-
-        If you want to provide custom filters you can, like ``status`` in this case: ::
-
-            TierConfig.get(account_id=request.asset.tiers.tier1.id, status='pending')
-
-        :param Optional[str] account_id: Account id of the requested TierConfig
-            (an id beginning with ``TA-``).
-        :param Optional[str] product_id: Optional id of the product.
-        :param Optional[str] tier_id: Optional id of the requested TierConfig
-            (an id beginning with ``TC-``).
-        :param Config config: Config to use, or ``None`` to use environment config (default).
-        :param custom_filters: Additional filters to pass to the request.
-        :return: The requested TierConfig, or ``None`` if it was not found.
-        :rtype: Optional[TierConfig]
-        """
-        from connect.resources.base import ApiClient
-
-        filters = {'status': 'approved'}
-        if account_id:
-            filters['configuration__account__id'] = account_id
-        if product_id:
-            filters['configuration__product__id'] = product_id
-        if tier_id:
-            filters['configuration__id'] = tier_id
-        filters.update(custom_filters)
-
-        response, _ = ApiClient(config, base_path='tier/config-requests').get(params=filters)
-        objects = TierConfigRequest.deserialize(response)
-
-        if isinstance(objects, list) and len(objects) > 0:
-            return objects[0].configuration
-        else:
-            return None
-
     def get_param_by_id(self, id_):
         """ Get a Tier Config parameter.
 

--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -97,7 +97,7 @@ class FulfillmentAutomation(AutomationEngine):
             self._update_conversation_if_exists(conversation, request.id, skip)
             return skip.code
 
-    @deprecated(deprecated_in='16.0', details='Use ``TierConfig.get`` instead.')
+    @deprecated(deprecated_in='16.0', details='Use ``TierAccount.get_config`` instead.')
     def get_tier_config(self, tier_id, product_id):
         """
         Gets the specified tier config data. For example, to get Tier 1 configuration data

--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -97,7 +97,7 @@ class FulfillmentAutomation(AutomationEngine):
             self._update_conversation_if_exists(conversation, request.id, skip)
             return skip.code
 
-    @deprecated(deprecated_in='16.0', details='Use ``TierAccount.get_config`` instead.')
+    @deprecated(deprecated_in='16.0', details='Use ``TierConfig.get`` instead.')
     def get_tier_config(self, tier_id, product_id):
         """
         Gets the specified tier config data. For example, to get Tier 1 configuration data

--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -5,7 +5,6 @@
 
 from abc import ABCMeta
 
-from deprecation import deprecated
 from typing import Optional
 
 from connect.exceptions import FailRequest, InquireRequest, SkipRequest
@@ -97,15 +96,15 @@ class FulfillmentAutomation(AutomationEngine):
             self._update_conversation_if_exists(conversation, request.id, skip)
             return skip.code
 
-    @deprecated(deprecated_in='16.0', details='Use ``TierConfig.get`` instead.')
-    def get_tier_config(self, tier_id, product_id):
+    def get_tier_config(self, account_id, product_id):
         """
         Gets the specified tier config data. For example, to get Tier 1 configuration data
         for one request, within the FulfillmentAutomation instance, we can do: ::
 
             self.get_tier_config(request.asset.tiers.tier1.id, request.asset.product.id)
 
-        :param str tier_id: Id of the requested Tier Config.
+        :param str account_id: Account id of the requested TierConfig
+            (an id beginning with ``TA-``).
         :param str product_id: Id of the product.
         :return: The requested Tier Config, or ``None`` if it was not found.
         :rtype: Optional[TierConfig]
@@ -114,7 +113,7 @@ class FulfillmentAutomation(AutomationEngine):
         params = {
             'status': 'approved',
             'configuration__product__id': product_id,
-            'configuration__account__id': tier_id,
+            'configuration__account__id': account_id,
         }
         response, _ = self._api.get(url=url, params=params)
         objects = TierConfigRequest.deserialize(response)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,8 +9,7 @@ import os
 import six
 from mock import MagicMock, patch
 
-from connect.models import Asset, Param, Fulfillment, Item, TierConfig, TierAccount, \
-    TierConfigRequest
+from connect.models import Asset, Param, Fulfillment, Item, TierConfig
 from connect.resources import FulfillmentAutomation
 from .common import Response, load_str
 
@@ -157,9 +156,9 @@ def test_asset_methods():
 
 
 @patch('requests.get')
-def test_tier_account_get_config(get_mock):
+def test_tier_config_get_with_account(get_mock):
     get_mock.return_value = _get_response_tier_config_ok()
-    config = TierAccount.get_config('account_id', 'product_id')
+    config = TierConfig.get(account_id='account_id', product_id='product_id')
     assert isinstance(config, TierConfig)
     get_mock.assert_called_with(
         url='http://localhost:8080/api/public/v1/tier/config-requests/',
@@ -171,27 +170,10 @@ def test_tier_account_get_config(get_mock):
             'configuration__account__id': 'account_id',
             'configuration__product__id': 'product_id'})
 
-
 @patch('requests.get')
-def test_tier_account_get_request(get_mock):
+def test_tier_config_get_with_tier(get_mock):
     get_mock.return_value = _get_response_tier_config_ok()
-    request = TierAccount.get_request('account_id', 'product_id')
-    assert isinstance(request, TierConfigRequest)
-    get_mock.assert_called_with(
-        url='http://localhost:8080/api/public/v1/tier/config-requests/',
-        headers={
-            'Content-Type': 'application/json',
-            'Authorization': 'ApiKey XXXX:YYYYY'},
-        params={
-            'status': 'approved',
-            'configuration__account__id': 'account_id',
-            'configuration__product__id': 'product_id'})
-
-
-@patch('requests.get')
-def test_tier_config_get(get_mock):
-    get_mock.return_value = _get_response_tier_config_ok()
-    config = TierConfig.get('tier_id', 'product_id')
+    config = TierConfig.get(tier_id='tier_id', product_id='product_id')
     assert isinstance(config, TierConfig)
     get_mock.assert_called_with(
         url='http://localhost:8080/api/public/v1/tier/config-requests/',
@@ -205,18 +187,21 @@ def test_tier_config_get(get_mock):
 
 
 @patch('requests.get')
-def test_tier_config_request_get(get_mock):
+def test_tier_config_get_with_custom_filter(get_mock):
     get_mock.return_value = _get_response_tier_config_ok()
-    request = TierConfigRequest.get('request_id', 'product_id')
-    assert isinstance(request, TierConfigRequest)
+    config = TierConfig.get(tier_id='tier_id', product_id='product_id', limit=100)
+    assert isinstance(config, TierConfig)
     get_mock.assert_called_with(
-        url='http://localhost:8080/api/public/v1/tier/config-requests/request_id',
+        url='http://localhost:8080/api/public/v1/tier/config-requests/',
         headers={
             'Content-Type': 'application/json',
             'Authorization': 'ApiKey XXXX:YYYYY'},
         params={
             'status': 'approved',
-            'configuration__product__id': 'product_id'})
+            'configuration__id': 'tier_id',
+            'configuration__product__id': 'product_id',
+            'limit': 100
+        })
 
 
 @patch('requests.get', MagicMock(return_value=Response(ok=True, text='[]', status_code=200)))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -167,8 +167,8 @@ def test_get_tier_config(get_mock):
             'Authorization': 'ApiKey XXXX:YYYYY'},
         params={
             'status': 'approved',
-            'configuration.product.id': 'product_id',
-            'configuration.id': 'tier_id'})
+            'configuration__id': 'tier_id',
+            'configuration__product__id': 'product_id'})
 
 
 @patch('requests.get', MagicMock(return_value=Response(ok=True, text='[]', status_code=200)))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -168,7 +168,7 @@ def test_get_tier_config(get_mock):
         params={
             'status': 'approved',
             'configuration.product.id': 'product_id',
-            'configuration.account.id': 'tier_id'})
+            'configuration.id': 'tier_id'})
 
 
 @patch('requests.get', MagicMock(return_value=Response(ok=True, text='[]', status_code=200)))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -156,52 +156,19 @@ def test_asset_methods():
 
 
 @patch('requests.get')
-def test_tier_config_get_with_account(get_mock):
+def test_get_tier_config(get_mock):
     get_mock.return_value = _get_response_tier_config_ok()
-    config = TierConfig.get(account_id='account_id', product_id='product_id')
+    config = FulfillmentAutomation().get_tier_config('account_id', 'product_id')
     assert isinstance(config, TierConfig)
     get_mock.assert_called_with(
-        url='http://localhost:8080/api/public/v1/tier/config-requests/',
+        url='http://localhost:8080/api/public/v1/tier/config-requests',
         headers={
             'Content-Type': 'application/json',
             'Authorization': 'ApiKey XXXX:YYYYY'},
         params={
             'status': 'approved',
-            'configuration__account__id': 'account_id',
-            'configuration__product__id': 'product_id'})
-
-@patch('requests.get')
-def test_tier_config_get_with_tier(get_mock):
-    get_mock.return_value = _get_response_tier_config_ok()
-    config = TierConfig.get(tier_id='tier_id', product_id='product_id')
-    assert isinstance(config, TierConfig)
-    get_mock.assert_called_with(
-        url='http://localhost:8080/api/public/v1/tier/config-requests/',
-        headers={
-            'Content-Type': 'application/json',
-            'Authorization': 'ApiKey XXXX:YYYYY'},
-        params={
-            'status': 'approved',
-            'configuration__id': 'tier_id',
-            'configuration__product__id': 'product_id'})
-
-
-@patch('requests.get')
-def test_tier_config_get_with_custom_filter(get_mock):
-    get_mock.return_value = _get_response_tier_config_ok()
-    config = TierConfig.get(tier_id='tier_id', product_id='product_id', limit=100)
-    assert isinstance(config, TierConfig)
-    get_mock.assert_called_with(
-        url='http://localhost:8080/api/public/v1/tier/config-requests/',
-        headers={
-            'Content-Type': 'application/json',
-            'Authorization': 'ApiKey XXXX:YYYYY'},
-        params={
-            'status': 'approved',
-            'configuration__id': 'tier_id',
             'configuration__product__id': 'product_id',
-            'limit': 100
-        })
+            'configuration__account__id': 'account_id'})
 
 
 @patch('requests.get', MagicMock(return_value=Response(ok=True, text='[]', status_code=200)))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,8 @@ import os
 import six
 from mock import MagicMock, patch
 
-from connect.models import Asset, Param, Fulfillment, Item, TierConfig
+from connect.models import Asset, Param, Fulfillment, Item, TierConfig, TierAccount, \
+    TierConfigRequest
 from connect.resources import FulfillmentAutomation
 from .common import Response, load_str
 
@@ -156,7 +157,39 @@ def test_asset_methods():
 
 
 @patch('requests.get')
-def test_get_tier_config(get_mock):
+def test_tier_account_get_config(get_mock):
+    get_mock.return_value = _get_response_tier_config_ok()
+    config = TierAccount.get_config('account_id', 'product_id')
+    assert isinstance(config, TierConfig)
+    get_mock.assert_called_with(
+        url='http://localhost:8080/api/public/v1/tier/config-requests/',
+        headers={
+            'Content-Type': 'application/json',
+            'Authorization': 'ApiKey XXXX:YYYYY'},
+        params={
+            'status': 'approved',
+            'configuration__account__id': 'account_id',
+            'configuration__product__id': 'product_id'})
+
+
+@patch('requests.get')
+def test_tier_account_get_request(get_mock):
+    get_mock.return_value = _get_response_tier_config_ok()
+    request = TierAccount.get_request('account_id', 'product_id')
+    assert isinstance(request, TierConfigRequest)
+    get_mock.assert_called_with(
+        url='http://localhost:8080/api/public/v1/tier/config-requests/',
+        headers={
+            'Content-Type': 'application/json',
+            'Authorization': 'ApiKey XXXX:YYYYY'},
+        params={
+            'status': 'approved',
+            'configuration__account__id': 'account_id',
+            'configuration__product__id': 'product_id'})
+
+
+@patch('requests.get')
+def test_tier_config_get(get_mock):
     get_mock.return_value = _get_response_tier_config_ok()
     config = TierConfig.get('tier_id', 'product_id')
     assert isinstance(config, TierConfig)
@@ -168,6 +201,21 @@ def test_get_tier_config(get_mock):
         params={
             'status': 'approved',
             'configuration__id': 'tier_id',
+            'configuration__product__id': 'product_id'})
+
+
+@patch('requests.get')
+def test_tier_config_request_get(get_mock):
+    get_mock.return_value = _get_response_tier_config_ok()
+    request = TierConfigRequest.get('request_id', 'product_id')
+    assert isinstance(request, TierConfigRequest)
+    get_mock.assert_called_with(
+        url='http://localhost:8080/api/public/v1/tier/config-requests/request_id',
+        headers={
+            'Content-Type': 'application/json',
+            'Authorization': 'ApiKey XXXX:YYYYY'},
+        params={
+            'status': 'approved',
             'configuration__product__id': 'product_id'})
 
 


### PR DESCRIPTION
 Added methods to get TierConfigRequest and TierConfig objects by TCR, TC and TA ids.
 Made product id optional in requests and replaced dot notation with double underscore (since the former seems to have a bug).