### PR TITLE
Changed theme to sphinx_rtd_theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The theme for the documentation has been changed to the default ReadTheDocs one, wich uses a much nicer layout and design of the classes and their properties:

![docs](https://user-images.githubusercontent.com/46556266/59353669-c598ad80-8d23-11e9-9d6c-a040d497d96d.png)
