### PR TITLE
Catch generic Exception on dispatch and do Skip.

### DIFF
--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -97,6 +97,14 @@ class FulfillmentAutomation(AutomationEngine):
             self._update_conversation_if_exists(conversation, request.id, skip)
             return skip.code
 
+        except NotImplementedError:
+            raise
+
+        except Exception as ex:
+            logger.warning('Skipping request {} because an exception was raised: {}'
+                           .format(request.id, ex))
+            return ''
+
     @deprecated(deprecated_in='16.0', details='Use ``TierConfig.get`` instead.')
     def get_tier_config(self, tier_id, product_id):
         """

--- a/connect/resources/tier_config_automation.py
+++ b/connect/resources/tier_config_automation.py
@@ -67,6 +67,14 @@ class TierConfigAutomation(AutomationEngine):
         except SkipRequest as skip:
             return skip.code
 
+        except NotImplementedError:
+            raise
+
+        except Exception as ex:
+            logger.warning('Skipping request {} because an exception was raised: {}'
+                           .format(request.id, ex))
+            return ''
+
         return ''
 
     @function_log


### PR DESCRIPTION
If something bad happens while processing a request, the exception will be caught by the dispatcher so the program does not crash and the request is simply skipped.