### PR TITLE
Fixing TierConfig.get

### DIFF
--- a/connect/models/tier_config.py
+++ b/connect/models/tier_config.py
@@ -96,14 +96,14 @@ class TierConfig(BaseModel):
     """ (:py:class:`.BaseModel` | None) Reference to TCR. """
 
     @classmethod
-    def get(cls, tier_id, product_id, config=None):
+    def get(cls, account_id, product_id, config=None):
         """
         Gets the specified tier config data. For example, to get Tier 1 configuration data
         for one request we can do: ::
 
             TierConfig.get(request.asset.tiers.tier1.id, request.asset.product.id)
 
-        :param str tier_id: Id of the requested Tier Config.
+        :param str account_id: Account Id of the requested Tier Config (id with TA prefix).
         :param str product_id: Id of the product.
         :param Config config: Config to use, or ``None`` to use environment config (default).
         :return: The requested Tier Config, or ``None`` if it was not found.
@@ -114,8 +114,8 @@ class TierConfig(BaseModel):
         response, _ = ApiClient(config, base_path='tier/config-requests').get(
             params={
                 'status': 'approved',
-                'configuration.product.id': product_id,
-                'configuration.account.id': tier_id,
+                'configuration__product__id': product_id,
+                'configuration__account__id': account_id,
             }
         )
         objects = TierConfigRequest.deserialize(response)

--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -105,7 +105,7 @@ class FulfillmentAutomation(AutomationEngine):
 
             self.get_tier_config(request.asset.tiers.tier1.id, request.asset.product.id)
 
-        :param str tier_id: Id of the requested Tier Config.
+        :param str tier_id: Account Id of the requested Tier Config (id with TA prefix).
         :param str product_id: Id of the product.
         :return: The requested Tier Config, or ``None`` if it was not found.
         :rtype: Optional[TierConfig]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -158,7 +158,7 @@ def test_asset_methods():
 @patch('requests.get')
 def test_get_tier_config(get_mock):
     get_mock.return_value = _get_response_tier_config_ok()
-    config = TierConfig.get('tier_id', 'product_id')
+    config = TierConfig.get('account_id', 'product_id')
     assert isinstance(config, TierConfig)
     get_mock.assert_called_with(
         url='http://localhost:8080/api/public/v1/tier/config-requests/',
@@ -167,8 +167,8 @@ def test_get_tier_config(get_mock):
             'Authorization': 'ApiKey XXXX:YYYYY'},
         params={
             'status': 'approved',
-            'configuration.product.id': 'product_id',
-            'configuration.account.id': 'tier_id'})
+            'configuration__product__id': 'product_id',
+            'configuration__account__id': 'account_id'})
 
 
 @patch('requests.get', MagicMock(return_value=Response(ok=True, text='[]', status_code=200)))


### PR DESCRIPTION
The configuration.product.id and configuration.account.id filters do not work as expected. Reverting to configuration__product__id and configuration__account__id.