### PR TITLE
Added parsing of param property value_choices.

### DIFF
--- a/connect/models/parameters.py
+++ b/connect/models/parameters.py
@@ -59,6 +59,9 @@ class Param(BaseModel):
     value_choice = None  # type: Optional[List[str]]
     """ (List[str]|None) Available choices for parameter. """
 
+    value_choices = None  # type: Optional[List[ValueChoice]]
+    """ (List[str]|None) Available dropdown choices for parameter. """
+
     # Undocumented fields (they appear in PHP SDK)
     title = None  # type: Optional[str]
     """ (str|None) Title for parameter. """

--- a/connect/models/schemas.py
+++ b/connect/models/schemas.py
@@ -337,6 +337,7 @@ class ParamSchema(BaseSchema):
     value = fields.Str(allow_none=True)
     value_error = fields.Str(allow_none=True)
     value_choice = fields.Str(many=True, allow_none=True)
+    value_choices = fields.Nested(ValueChoiceSchema, many=True, allow_none=True)
 
     # Undocumented fields (they appear in PHP SDK)
     title = fields.Str(allow_none=True)


### PR DESCRIPTION
Added parsing of param property value_choices. I could not find this property on the Connect API docs, perhaps it should be updated?

There is a similar value_choice in the docs, but it contains a list of strings, while this contains a list of objects with "label" and "value" fields.