### PR TITLE
CPS-61 Fixed repeated log lines.

### DIFF
--- a/connect/resources/automation_engine.py
+++ b/connect/resources/automation_engine.py
@@ -61,7 +61,7 @@ class AutomationEngine(BaseResource):
         log_level = global_logger.level
         self.__class__.logger.setLevel(log_level)
         self.__class__.logger.propagate = False
-        [self.__class__.logger.addHandler(hdlr) for hdlr in handlers]
+        self.__class__.logger.handlers = handlers
         base = " %(levelname)-6s; %(asctime)s; %(name)-6s; %(module)s:%(funcName)s:line" \
                "-%(lineno)d: %(message)s"
         sformat = " ".join(args) + base


### PR DESCRIPTION
Due to a bug the log handler was being added for every request, causing log messages being printed twice on the 2nd requests, thrice on the third request, etc.