### PR TITLE
CPS-66-usage-file-action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Connect SDK Changes History
 
+## v17.5
+
+* Fix: UsageFileAction's subclass SubmitUsageFile has a rejection note, a parameter which should go in RejectUsageFile instead.
+
 ## v17.4
 
 * Fix: Due to a bug the log handler was being added for every request, causing log messages being printed twice on the 2nd requests, thrice on the third request, etc.

--- a/connect/exceptions.py
+++ b/connect/exceptions.py
@@ -121,18 +121,18 @@ class DeleteUsageFile(UsageFileAction):
 
 
 class RejectUsageFile(UsageFileAction):
-    def __init__(self, message=None):
+    def __init__(self, rejection_note):
         # type: (str) -> None
-        super(RejectUsageFile, self).__init__(message or 'Accept Response is required', 'reject')
+        super(RejectUsageFile, self).__init__(
+            'Reject Response is required',
+            'reject',
+            {'rejection_note': rejection_note})
 
 
 class SubmitUsageFile(UsageFileAction):
-    def __init__(self, rejection_note):
-        # type: (str) -> None
-        super(SubmitUsageFile, self).__init__(
-            'Usage File Submitted',
-            'submit',
-            {'rejection_note': rejection_note})
+    def __init__(self):
+        # type: () -> None
+        super(SubmitUsageFile, self).__init__('Usage File Submitted', 'submit')
 
 
 class FileCreationError(Message):

--- a/examples/usage_file.py
+++ b/examples/usage_file.py
@@ -30,7 +30,7 @@ class UsageFileExample(UsageFileAutomation):
             raise DeleteUsageFile('Not needed anymore')
         elif request.status == 'ready':
             # Vendor may submit file to provider
-            raise SubmitUsageFile('Ready for provider')
+            raise SubmitUsageFile()
         elif request.status == 'pending':
             # Provider use case, needs to be reviewed and accepted
             raise AcceptUsageFile('File looks good')

--- a/tests/test_usage_file.py
+++ b/tests/test_usage_file.py
@@ -122,6 +122,6 @@ class UsageFileAutomationTester(UsageFileAutomation):
         elif request.id == 'UF-2018-11-9878764342-reject':
             raise RejectUsageFile('Rejecting the file as a test')
         elif request.id == 'UF-2018-11-9878764342-submit':
-            raise SubmitUsageFile('Submitting file')
+            raise SubmitUsageFile()
         elif request.id == 'UF-2018-11-9878764342-skip':
             raise SkipRequest('Skipping')


### PR DESCRIPTION
UsageFileAction's subclass SubmitUsageFile has a rejection note, a parameter which should go in RejectUsageFile instead.